### PR TITLE
Resolve `coords_to_fips` order list error

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -28,21 +28,18 @@ jobs:
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
 
-          # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-18.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
-          - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
+          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-latest,   r: 'oldrel-1'}
+          - {os: ubuntu-latest,   r: 'oldrel-2'}
+          - {os: ubuntu-latest,   r: 'oldrel-3'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-pandoc@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,14 @@
 # fipio 1.1.1.9000
 
+- Fixed `coords_to_fips()` throwing `order` error due to `ret_index` being a list ([#15](https://github.com/program--/fipio/issues/15))
+- Return documentation back to linking to https://github.com/program-- instead of UFOKN's GitHub org.
+
 # fipio 1.1.1
 
 - Added [Mike Johnson](https://github.com/mikejohnson51) to `DESCRIPTION`.
-- Fixed `coords_to_fips()` throwing error in some edge cases ([#11](https://github.com/UFOKN/fipio/issues/11)).
-- Fixed `as_fips()` throwing error for unknown states. ([#10](https://github.com/UFOKN/fipio/issues/10)).
-- Fixed `as_fips()` edge case throwing error ([#13](https://github.com/UFOKN/fipio/pull/13)).
+- Fixed `coords_to_fips()` throwing error in some edge cases ([#11](https://github.com/program--/fipio/issues/11)).
+- Fixed `as_fips()` throwing error for unknown states. ([#10](https://github.com/program--/fipio/issues/10)).
+- Fixed `as_fips()` edge case throwing error ([#13](https://github.com/program--/fipio/pull/13)).
 
 # fipio 1.1.0
 

--- a/R/geolocate.R
+++ b/R/geolocate.R
@@ -74,6 +74,8 @@ coords_to_fips.numeric <- function(x, y, ...) {
     lookup_geometry <- .geometry_fips[county_fips]
     rm(county_fips)
 
+    # Filter out geometries by bounding box,
+    # like a spatial index
     intersected <- which(sapply(
         lookup_geometry,
         FUN = function(g) {
@@ -84,15 +86,15 @@ coords_to_fips.numeric <- function(x, y, ...) {
         USE.NAMES = FALSE
     ))
 
+    # Get fips and geometry based on `intersected`
     lookup_fips     <- lookup_fips[intersected]
     lookup_geometry <- lookup_geometry[intersected]
 
-    ret_index <- sapply(
+    ret_index <- lapply(
         lookup_geometry,
         FUN = .intersects,
         x = x,
-        y = y,
-        USE.NAMES = FALSE
+        y = y
     )
 
     ret_value <- .pad0(lookup_fips)[!is.na(ret_index)]
@@ -100,5 +102,10 @@ coords_to_fips.numeric <- function(x, y, ...) {
 
     rm(lookup_fips, lookup_geometry)
 
-    ret_value[order(ret_index)]
+    result <- character(length(x))
+    for (ind in seq_along(ret_value)) {
+        result[ret_index[[ind]]] <- ret_value[ind]
+    }
+
+    result
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,13 +13,13 @@ knitr::opts_chunk$set(
 )
 ```
 
-# fipio <a href="https://github.com/UFOKN/fipio"><img src="man/figures/logo.png" align="right" width="25%"/></a>
+# fipio <a href="https://github.com/program--/fipio"><img src="man/figures/logo.png" align="right" width="25%"/></a>
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/fipio)](https://CRAN.R-project.org/package=fipio)
 [![CRAN downloads](https://cranlogs.r-pkg.org/badges/fipio)](https://CRAN.R-project.org/package=fipio)
-[![codecov](https://codecov.io/gh/UFOKN/fipio/branch/master/graph/badge.svg)](https://app.codecov.io/gh/UFOKN/fipio)
-[![R-CMD-check](https://github.com/UFOKN/fipio/workflows/R-CMD-check/badge.svg)](https://github.com/UFOKN/fipio/actions)
+[![codecov](https://codecov.io/gh/program--/fipio/branch/master/graph/badge.svg)](https://app.codecov.io/gh/program--/fipio)
+[![R-CMD-check](https://github.com/program--/fipio/workflows/R-CMD-check/badge.svg)](https://github.com/program--/fipio/actions)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 <!-- badges: end -->
 
@@ -36,10 +36,10 @@ install.packages("fipio")
 or the development version with `pak` or `remotes`:
 ``` r
 # Using `pak`
-pak::pkg_install("UFOKN/fipio")
+pak::pkg_install("program--/fipio")
 
 # Using `remotes`
-remotes::install_github("UFOKN/fipio")
+remotes::install_github("program--/fipio")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# fipio <a href="https://github.com/UFOKN/fipio"><img src="man/figures/logo.png" align="right" width="25%"/></a>
+# fipio <a href="https://github.com/program--/fipio"><img src="man/figures/logo.png" align="right" width="25%"/></a>
 
 <!-- badges: start -->
 
@@ -9,8 +9,8 @@
 status](https://www.r-pkg.org/badges/version/fipio)](https://CRAN.R-project.org/package=fipio)
 [![CRAN
 downloads](https://cranlogs.r-pkg.org/badges/fipio)](https://CRAN.R-project.org/package=fipio)
-[![codecov](https://codecov.io/gh/UFOKN/fipio/branch/master/graph/badge.svg)](https://app.codecov.io/gh/UFOKN/fipio)
-[![R-CMD-check](https://github.com/UFOKN/fipio/workflows/R-CMD-check/badge.svg)](https://github.com/UFOKN/fipio/actions)
+[![codecov](https://codecov.io/gh/program--/fipio/branch/master/graph/badge.svg)](https://app.codecov.io/gh/program--/fipio)
+[![R-CMD-check](https://github.com/program--/fipio/workflows/R-CMD-check/badge.svg)](https://github.com/program--/fipio/actions)
 [![MIT
 License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 <!-- badges: end -->
@@ -31,10 +31,10 @@ or the development version with `pak` or `remotes`:
 
 ``` r
 # Using `pak`
-pak::pkg_install("UFOKN/fipio")
+pak::pkg_install("program--/fipio")
 
 # Using `remotes`
-remotes::install_github("UFOKN/fipio")
+remotes::install_github("program--/fipio")
 ```
 
 ## Usage

--- a/tests/testthat/test-fipio.R
+++ b/tests/testthat/test-fipio.R
@@ -105,6 +105,7 @@ testthat::test_that("as_fips edge cases", {
 # Coverage for match(), .has_fastmatch(), .onLoad()
 testthat::test_that("`fmatch` is assigned to `match` if it is installed", {
     testthat::skip_if(!requireNamespace("mockery", quietly = TRUE))
+    testthat::skip_if(!requireNamespace("fastmatch", quietly = TRUE))
     m <- mockery::mock(FALSE, TRUE)
     mockery::stub(expect_match_assignment, ".has_fastmatch", m)
 


### PR DESCRIPTION
This PR is required for #15.

The general issue is detailed in the issue, but summarized:
- Something (not sure exactly) caused `ret_index` to become a list rather than a vector, which caused an error when `order(ret_index)` was called in the return statement.
- This PR rectifies that by explicitly ordering by iterating over `ret_index` and setting the FIPSs into a result vector.